### PR TITLE
[SWEA] #1289 원재의 메모리 복구하기

### DIFF
--- a/_2024_08_21/소남주/SWEA_1289_원재의_메모리_복구하기.java
+++ b/_2024_08_21/소남주/SWEA_1289_원재의_메모리_복구하기.java
@@ -1,0 +1,56 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+public class Solution {
+	
+	static BufferedReader br;
+	static StringBuilder sb;
+	
+	static int[] originalNum; // 만들어야 하는 숫자
+	static int[] currentNum; // 현재 숫자
+	
+	static int answer; // 최소 수정 횟수
+	
+	public static void main(String[] args) throws IOException {
+		
+		br = new BufferedReader(new InputStreamReader(System.in));
+		sb = new StringBuilder();
+		
+		final int T = Integer.parseInt(br.readLine());
+		
+		for (int testCase = 1; testCase <= T; testCase++) {
+			sb.append("#").append(testCase).append(" ");
+			
+			String[] input = br.readLine().split("");
+			
+			originalNum = new int[input.length];
+			for (int i = 0; i < input.length; i++) {
+				originalNum[i] = Integer.parseInt(input[i]);
+			}
+			
+			currentNum = new int[originalNum.length];
+			
+			answer = 0;
+			
+			for (int i = 0; i < originalNum.length; i++) {
+				if (currentNum[i] != originalNum[i]) {
+					changeNum(i);
+					answer++;
+				}
+			}
+			
+			sb.append(answer).append("\n");
+		}
+		
+		System.out.println(sb.toString());
+		
+	}
+	
+	static void changeNum(int startIdx) {
+		 for (int i = startIdx; i < currentNum.length; i++) {
+			 currentNum[i] = (currentNum[i] + 1) % 2;
+		 }
+	}
+	
+}


### PR DESCRIPTION
# 문제

원재가 컴퓨터를 만지다가 실수를 저지르고 말았다. 메모리가 초기화된 것이다.

다행히 원래 메모리가 무슨 값이었는지 알고 있었던 원재는 바로 원래 값으로 되돌리려고 했으나 메모리 값을 바꿀 때 또 문제가 생겼다.

메모리 bit중 하나를 골라 0인지 1인지 결정하면 해당 값이 메모리의 끝까지 덮어씌우는 것이다.

예를 들어 지금 메모리 값이 0100이고, 3번째 bit를 골라 1로 설정하면 0111이 된다.

원래 상태가 주어질 때 초기화 상태 (모든 bit가 0) 에서 원래 상태로 돌아가는데 최소 몇 번이나 고쳐야 하는지 계산해보자.
<br/>

**[입력]**

첫 번째 줄에 테스트 케이스의 수 T가 주어진다.

각 테스트 케이스는 한 줄로 이루어져 있으며, 메모리의 원래 값이 주어진다.

메모리의 길이는 1이상 50이하이다.
<br/>

**[출력]**

각 테스트 케이스마다 ‘#x’(x는 테스트케이스 번호를 의미하며 1부터 시작한다)를 출력하고,

초기값(모든bit가 0)에서 원래 값으로 복구하기 위한 최소 수정 횟수를 출력한다.
<br/>

**[input]**
```
10
01010101010101010101010101010101010101010101010101
01
1000110010011111010110000100100000000001001
10011010001110111010111010001100101101
00110101100001010000110010111
101111110101010100111100101111001
01110011110001110
1010101001010101010101010100111111
01010100010100101100111010100010111111011001011000
1111100101101110000
```
<br/>

**[output]**
```
#1 49
#2 1
#3 19
#4 23
#5 15
#6 19
#7 6
#8 27
#9 30
#10 8
```